### PR TITLE
add placeholder to items controller in private params

### DIFF
--- a/backend/app/controllers/items_controller.rb
+++ b/backend/app/controllers/items_controller.rb
@@ -94,5 +94,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:title, :description, :image, tag_list: [])
+    with_defaults(image: "/placeholder.png")
   end
 end

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Issue

When adding a new item in `/editor` the `image_url` field is not mandatory. 

If a user uploads an item without an image it presents as a broken image link.

# Solution

Load the `/frontend/public/placeholder.png` if an image is not uploaded correctly.

# Screenshot of Fix

<img width="749" alt="Screen Shot 2022-09-25 at 12 43 34 pm" src="https://user-images.githubusercontent.com/4454398/192126645-95dafb9f-fd86-4214-8c40-75add4458a3a.png">